### PR TITLE
Fix false positive in russian language detection

### DIFF
--- a/src/transliterate/base.py
+++ b/src/transliterate/base.py
@@ -264,10 +264,10 @@ class TranslitLanguagePack(object):
         """
         if cls.character_ranges:
             char_num = unicodedata.normalize('NFC', character)
-            char_num = hex(ord(char_num))
+            char_num = ord(char_num)
             for character_range in cls.character_ranges:
-                range_lower = hex(character_range[0])
-                range_upper = hex(character_range[1])
+                range_lower = character_range[0]
+                range_upper = character_range[1]
                 if char_num >= range_lower and char_num <= range_upper:
                     return True
         return False

--- a/src/transliterate/tests/test_transliterate.py
+++ b/src/transliterate/tests/test_transliterate.py
@@ -364,6 +364,15 @@ class TransliterateTest(unittest.TestCase):
         return res
 
     @print_info
+    def test_25_false_language_detection_cyrillic(self):
+        """
+        Testing language detection. Detecting is not Russian (Cyrillic).
+        """
+        res = detect_language(self.latin_text)
+        self.assertNotEqual(res, 'ru')
+        return res
+
+    @print_info
     def __test_25_language_detection_ukrainian_cyrillic(self):
         """
         Testing language detection. Detecting Ukrainian (Cyrillic).


### PR DESCRIPTION
I found that transliterate.detect_language(u'John Smith') returns 'ru'. I think this is a bug and propose to consider my fix and test.