### PR TITLE
Greek: Fix the uppercase theta translit mapping

### DIFF
--- a/src/transliterate/contrib/languages/el/data/python32.py
+++ b/src/transliterate/contrib/languages/el/data/python32.py
@@ -9,8 +9,8 @@ reversed_specific_mapping = (
     "saeiiyooiyiyooiier"
 )
 pre_processor_mapping = {
-    "th": "ϑ",
-    "Th": "θ",
+    "th": "θ",
+    "Th": "Θ",
     "ch": "χ",
     "Ch": "Χ",
     "ps": "ψ",

--- a/src/transliterate/contrib/languages/el/data/standard.py
+++ b/src/transliterate/contrib/languages/el/data/standard.py
@@ -9,8 +9,8 @@ reversed_specific_mapping = (
     u"saeiiyooiyiyooiier"
 )
 pre_processor_mapping = {
-    u"th": u"ϑ",
-    u"Th": u"θ",
+    u"th": u"θ",
+    u"Th": u"Θ",
     u"ch": u"χ",
     u"Ch": u"Χ",
     u"ps": u"ψ",


### PR DESCRIPTION
transliterate python module has a wrong mapping for the Greek theta
letters. There is no mapping for the uppercase theta letter while there
is a mapping for the Greek theta symbol U+03D1. The small and capital
theta letters emitted by Greek keyboards are U+03B8 and U+0398
respectively. Remove the mapping for the symbol, fix the mapping for the
small theta letter, add the mapping for the capital theta letter.
