### PR TITLE
Update default.py

### DIFF
--- a/src/transliterate/contrib/languages/ka/data/default.py
+++ b/src/transliterate/contrib/languages/ka/data/default.py
@@ -1,32 +1,29 @@
 # -*- coding: utf-8 -*-
 
 mapping = (
-    u"abgdezilkhmjnpsvturqoABGDEZILKHMJNPSVTURQO",
-    u"აბგდეზილქჰმჯნფსვთურყოႠႡႢႣႤႦႨႪႵჀႫႿႼႴႱႥႧႳႰႷႭ",
+    u"abgdevztiklmnoprsufqycxjhwABGDEVIKLMNOPUFQYXH",
+    u"აბგდევზთიკლმნოპრსუფქყცხჯჰწაბგდებიკლმნოპუფქყხჰ",
 )
+
+
+
+
 pre_processor_mapping = {
-    u"k'": u"კ",
-    u"p'": u"პ",
     u"zh'": u"ჟ",
-    u"t'": u"ტ",
+    u"T'": u"ტ",
     u"gh": u"ღ",
     u"sh": u"შ",
     u"ch": u"ჩ",
-    u"ts": u"ც",
+    u"W'": u"ჭ",
+    u"ch'": u"ჭ",
     u"dz": u"ძ",
     u"ts'": u"წ",
-    u"ch'": u"ჭ",
     u"kh": u"ხ",
-    u"K'": u"Ⴉ",
-    u"P'": u"Ⴎ",
-    u"Zh'": u"Ⴏ",
-    u"T'": u"Ⴒ",
-    u"Gh": u"Ⴖ",
-    u"Sh": u"Ⴘ",
-    u"Ch": u"Ⴙ",
-    u"Ts": u"Ⴚ",
-    u"Dz": u"Ⴛ",
-    u"Ts'": u"Ⴜ",
-    u"Ch'": u"Ⴝ",
-    u"Kh": u"Ⴞ",
+    u"R'": u"ღ",
+    u"S'": u"შ",
+    u"J'": u"ჟ",
+    u"C'": u"ჩ",
+    u"Z'": u"ძ",
+
 }
+


### PR DESCRIPTION
I updated the "mapping" tuple because Georgia language does not use letters, such as "Ⴀ, Ⴁ, Ⴂ, Ⴃ, Ⴄ, Ⴆ, Ⴈ, Ⴊ, Ⴕ, Ⴠ, Ⴋ, Ⴟ, Ⴜ, Ⴔ, Ⴑ, Ⴅ, Ⴇ, Ⴓ, Ⴐ, Ⴗ, Ⴍ" because they are very old and was used by Georgian ancestors. 

Also, I changed "pre_processor_mapping" as well because the mapping, which was proposed 
    u"K'": u"Ⴉ",
    u"P'": u"Ⴎ",
    u"Zh'": u"Ⴏ",
    u"T'": u"Ⴒ",
    u"Gh": u"Ⴖ",
    u"Sh": u"Ⴘ",
    u"Ch": u"Ⴙ",
    u"Ts": u"Ⴚ",
    u"Dz": u"Ⴛ",
    u"Ts'": u"Ⴜ",
    u"Ch'": u"Ⴝ",
    u"Kh": u"Ⴞ",
contained some errors, which in turn gives us inaccurate results after transliteration.