### PR TITLE
Transliteration - Bulgarian

### DIFF
--- a/src/transliterate/contrib/languages/bg/data/default.py
+++ b/src/transliterate/contrib/languages/bg/data/default.py
@@ -24,5 +24,7 @@ pre_processor_mapping = {
     u"Sh": u"Ш",
     u"Sht": u"Щ",
     u"Yu": u"Ю",
-    u"Ya": u"Я"
+    u"Ya": u"Я",
+    u"Q": u"Я", # Bulgarians typers often use "Q" for "Я". Example: KNQZ => КНЯЗ
+    u"q": u"Я", # Bulgarians typers often use "q" for "я". Example: pepelqshka => пепеляшка   
 }


### PR DESCRIPTION
Add transliteration cases for Bulgarian usage of Cyrillic characters "Я" and "я". Bulgarian typers often use "Q" and "q" for "Я" and "я". Before making this pull request I have researched about cases when this transliteration might fail to work (like "Quantum computing"), but according my findings (and own experience) no one from Bulgaria would use "Q","q" for anything else except "Я" and "я". Therefore, I hope this merge is accepted.