### PR TITLE
Remove the "oy" pre processor mapping for greek

### DIFF
--- a/src/transliterate/contrib/languages/el/data/default.py
+++ b/src/transliterate/contrib/languages/el/data/default.py
@@ -43,8 +43,6 @@ pre_processor_mapping = {
     u"eu": u"ευ",
     u"Ou": u"Ου",
     u"ou": u"ου",
-    u"Oy": u"Ου",
-    u"oy": u"ου",
     u"U": u"Υ",
     u"u": u"υ",
     u"Yi": u"Υι",


### PR DESCRIPTION
"ου" in both ISO 843[1], the international ratification of ELOT 743 v1
with a couple of minor differences, and ELOT 743 version 2 type 1 [2]
(the Greek cross ratification of ISO 843 to adopt the above minor
differences) specifically set an exception for the double vowel "ου",
which needs to be transliterated as "ou" and vice versa. There is no
mapping exception to/from "oy", so while "oy" would be transliterated,
per the general rules, to "ου" the inverse would never be true in a
transliteration context.

It's important to note that nor the UN nor the ALA-LC
(library of congress) treat "ου" differently than ISO-843/ELOT 743 v2
(which isn't the case for some other mappings).

This closes #47

Signed-off-by: Alexandros Kosiaris <akosiaris@gmail.com>